### PR TITLE
[WIP] Configurable Post Routes

### DIFF
--- a/app/Http/Controllers/Frontend/BlogController.php
+++ b/app/Http/Controllers/Frontend/BlogController.php
@@ -39,19 +39,19 @@ class BlogController extends Controller
         $user = User::findOrFail(1);
         $required = config('blog.post_params', []);
         $post = Post::with('tags')
-            ->when(in_array('slug', $required), function($query) use($request) {
+            ->when(in_array('slug', $required), function ($query) use ($request) {
                 return $query->whereSlug($request->route('slug'));
             })
-            ->when(in_array('id', $required), function($query) use($request) {
+            ->when(in_array('id', $required), function ($query) use ($request) {
                 return $query->whereId($request->route('id'));
             })
-            ->when(in_array('year', $required), function($query) use($request) {
+            ->when(in_array('year', $required), function ($query) use ($request) {
                 return $query->whereYear('published_at', $request->route('year'));
             })
-            ->when(in_array('month', $required), function($query) use($request) {
+            ->when(in_array('month', $required), function ($query) use ($request) {
                 return $query->whereMonth('published_at', $request->route('month'));
             })
-            ->when(in_array('day', $required), function($query) use($request) {
+            ->when(in_array('day', $required), function ($query) use ($request) {
                 return $query->whereDay('published_at', $request->route('day'));
             })
             ->firstOrFail();

--- a/app/Http/Controllers/Frontend/BlogController.php
+++ b/app/Http/Controllers/Frontend/BlogController.php
@@ -30,12 +30,32 @@ class BlogController extends Controller
     /**
      * Display the specified resource.
      *
+     * @param \Illuminate\Http\Request $request
+     *
      * @return \Illuminate\Http\Response
      */
-    public function showPost($slug, Request $request)
+    public function showPost(Request $request)
     {
         $user = User::findOrFail(1);
-        $post = Post::with('tags')->whereSlug($slug)->firstOrFail();
+        $required = config('blog.post_params', []);
+        $post = Post::with('tags')
+            ->when(in_array('slug', $required), function($query) use($request) {
+                return $query->whereSlug($request->route('slug'));
+            })
+            ->when(in_array('id', $required), function($query) use($request) {
+                return $query->whereId($request->route('id'));
+            })
+            ->when(in_array('year', $required), function($query) use($request) {
+                return $query->whereYear('published_at', $request->route('year'));
+            })
+            ->when(in_array('month', $required), function($query) use($request) {
+                return $query->whereMonth('published_at', $request->route('month'));
+            })
+            ->when(in_array('day', $required), function($query) use($request) {
+                return $query->whereDay('published_at', $request->route('day'));
+            })
+            ->firstOrFail();
+
         $tag = $request->get('tag');
         $title = $post->title;
         if ($tag) {

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -98,8 +98,14 @@ class Post extends Model
      */
     public function url(Tag $tag = null)
     {
-        $params = [];
-        $params['slug'] = $this->slug;
+        $params = array_only([
+            'id'    => $this->id,
+            'slug'  => $this->slug,
+            'year'  => $this->published_at->format('Y'),
+            'month' => $this->published_at->format('m'),
+            'day'   => $this->published_at->format('d'),
+        ], config('blog.post_params'));
+
         $params['tag'] = $tag ? $tag->tag : null;
 
         return route('blog.post.show', array_filter($params));

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -10,20 +10,32 @@ use Illuminate\Database\Eloquent\Model;
 class Post extends Model
 {
     /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = ['published_at'];
-
-    /**
      * The attributes that are mass assignable.
      *
      * @var array
      */
     protected $fillable = [
-        'title', 'subtitle', 'content_raw', 'page_image', 'meta_description',
-        'layout', 'is_draft', 'published_at', 'slug',
+        'title',
+        'subtitle',
+        'content_raw',
+        'page_image',
+        'meta_description',
+        'layout',
+        'is_draft',
+        'published_at',
+        'slug',
+    ];
+
+    protected $casts = [
+        'title'            => 'string',
+        'subtitle'         => 'string',
+        'content_raw'      => 'string',
+        'page_image'       => 'string',
+        'meta_description' => 'string',
+        'layout'           => 'string',
+        'is_draft'         => 'bool',
+        'published_at'     => 'datetime',
+        'slug'             => 'string',
     ];
 
     /**

--- a/config/blog.php
+++ b/config/blog.php
@@ -14,6 +14,14 @@ return [
     */
     'posts_per_page' => 6,
 
+    'post_params' => [
+//        'id',
+        'slug',
+//        'year',
+//        'month',
+//        'day',
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Canvas Configuration : Storage

--- a/tests/Models/PostTest.php
+++ b/tests/Models/PostTest.php
@@ -75,7 +75,7 @@ class PostTest extends EloquentTestCase
     public function testModelProperties()
     {
         $this->hasFillable('title', 'subtitle', 'content_raw', 'page_image', 'meta_description', 'layout', 'is_draft', 'published_at', 'slug')
-             ->hasDates('published_at')
+             ->hasCasts('published_at', 'is_draft')
              ->belongsToMany(Tag::class);
     }
 

--- a/tests/Models/PostTest.php
+++ b/tests/Models/PostTest.php
@@ -75,7 +75,8 @@ class PostTest extends EloquentTestCase
     public function testModelProperties()
     {
         $this->hasFillable('title', 'subtitle', 'content_raw', 'page_image', 'meta_description', 'layout', 'is_draft', 'published_at', 'slug')
-             ->hasCasts('published_at', 'is_draft')
+             ->hasCasts('published_at', 'datetime')
+             ->hasCasts('is_draft', 'bool')
              ->belongsToMany(Tag::class);
     }
 


### PR DESCRIPTION
As described in #167, this PR allows you to configure how post URLs are structured. With this you can do so in 2 steps.

The first is to change which url parameters are required in `config/blog.php`. You can do so by uncommenting the parameters you want in your url.

``` php
    'post_params' => [
//        'id',
        'slug',
        'year',
        'month',
        'day',
    ],
```

Second you'll want to change the `blog.post.show` route to include those parameters:

``` php
// Blog Post Page
Route::get('{year}/{month}/{day}/{slug}', 'Frontend\BlogController@showPost')->name('blog.post.show');
```

From there it should just work. 

Let me know what you think about this approach. Obviously there are some issues with upgrading in the future but I think we can address those using the approach Laravel Spark is taking as we talked about in #95 

fixes #167 
