### PR TITLE
Fix bug #322 - Installing with composer --no-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
+        "fzaninotto/faker": "~1.4",
         "laravel/framework": "5.3.*",
         "cnvs/easel": "3.2.*",
         "cnvs/paper-dark": "*",
         "doctrine/dbal": "2.5.*"
     },
     "require-dev": {
-        "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~5.0",
         "symfony/css-selector": "~3.0",


### PR DESCRIPTION
After installing and generating a blog, there is a phase for
deploying it. Normally with the composer tag --no-dev
to avoid installing development tools that are not required on a
production environment.

However, the autosetup tools of canvas require the use of faker
library so update canvas environment.

This commit just moves faker from "require-dev" to "require" so
that the toolchain is not broken.