### PR TITLE
maintainability updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
 	"require": {
 		"php": "^7.1.3",
 		"ext-json": "*",
-		"illuminate/support": "~5.8.0|~5.9.0",
-		"illuminate/contracts": "~5.8.0|~5.9.0"
+		"illuminate/support": "~5.8.0"
 	},
 	"require-dev": {
 		"mockery/mockery": "^1.1",

--- a/src/CanvasServiceProvider.php
+++ b/src/CanvasServiceProvider.php
@@ -7,8 +7,8 @@ use Illuminate\Events\Dispatcher;
 use Canvas\Console\InstallCommand;
 use Canvas\Console\PublishCommand;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Container\BindingResolutionException;
 
 class CanvasServiceProvider extends ServiceProvider
 {

--- a/src/CanvasServiceProvider.php
+++ b/src/CanvasServiceProvider.php
@@ -7,8 +7,8 @@ use Illuminate\Events\Dispatcher;
 use Canvas\Console\InstallCommand;
 use Canvas\Console\PublishCommand;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Support\ServiceProvider;
 
 class CanvasServiceProvider extends ServiceProvider
 {
@@ -22,29 +22,22 @@ class CanvasServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->registerEvents();
-        $this->registerRoutes();
-        $this->registerMigrations();
-        $this->registerPublishing();
-        $this->registerResources();
+        $this->handleConfig();
+        $this->handleEvents();
+        $this->handleRoutes();
+        $this->handleMigrations();
+        $this->handlePublishing();
+        $this->handleResources();
+        $this->handleCommands();
     }
 
     /**
-     * Register any package services.
+     * Register bindings in the container.
      *
      * @return void
      */
     public function register()
     {
-        $this->mergeConfigFrom(
-            __DIR__.'/../config/canvas.php', 'canvas'
-        );
-
-        $this->commands([
-            InstallCommand::class,
-            PublishCommand::class,
-            SetupCommand::class,
-        ]);
     }
 
     /**
@@ -53,7 +46,7 @@ class CanvasServiceProvider extends ServiceProvider
      * @return void
      * @throws BindingResolutionException
      */
-    private function registerEvents()
+    private function handleEvents()
     {
         $events = $this->app->make(Dispatcher::class);
 
@@ -69,7 +62,7 @@ class CanvasServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    private function registerRoutes()
+    private function handleRoutes()
     {
         Route::group($this->routeConfiguration(), function () {
             $this->loadRoutesFrom(__DIR__.'/../routes/canvas.php');
@@ -84,8 +77,8 @@ class CanvasServiceProvider extends ServiceProvider
     private function routeConfiguration()
     {
         return [
-            'namespace'  => 'Canvas\Http\Controllers',
-            'prefix'     => 'canvas',
+            'namespace' => 'Canvas\Http\Controllers',
+            'prefix' => 'canvas',
             'middleware' => config('canvas.middleware'),
         ];
     }
@@ -95,7 +88,7 @@ class CanvasServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    private function registerResources()
+    private function handleResources()
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'canvas');
     }
@@ -105,7 +98,7 @@ class CanvasServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    private function registerMigrations()
+    private function handleMigrations()
     {
         if ($this->app->runningInConsole()) {
             $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
@@ -117,7 +110,7 @@ class CanvasServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    private function registerPublishing()
+    private function handlePublishing()
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
@@ -129,8 +122,33 @@ class CanvasServiceProvider extends ServiceProvider
             ], 'canvas-config');
 
             $this->publishes([
-                __DIR__.'/../stubs/providers/CanvasServiceProvider.stub' => app_path('Providers/CanvasServiceProvider.php'),
+                __DIR__.'/../stubs/providers/CanvasServiceProvider.stub' => app_path(
+                    'Providers/CanvasServiceProvider.php'
+                ),
             ], 'canvas-provider');
         }
+    }
+
+    /**
+     * @return void
+     */
+    private function handleConfig(): void
+    {
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/canvas.php',
+            'canvas'
+        );
+    }
+
+    /**
+     * @return void
+     */
+    private function handleCommands(): void
+    {
+        $this->commands([
+            InstallCommand::class,
+            PublishCommand::class,
+            SetupCommand::class,
+        ]);
     }
 }

--- a/src/Http/Controllers/StatsController.php
+++ b/src/Http/Controllers/StatsController.php
@@ -13,7 +13,7 @@ class StatsController extends Controller
      *
      * @const int
      */
-    const DAYS_PRIOR = 30;
+    private const DAYS_PRIOR = 30;
 
     /**
      * Get all of the posts and views.

--- a/src/Http/Middleware/ViewThrottle.php
+++ b/src/Http/Middleware/ViewThrottle.php
@@ -13,7 +13,7 @@ class ViewThrottle
      *
      * @const int
      */
-    const EXPIRES_IN = 3600;
+    private const EXPIRES_IN = 3600;
 
     /**
      * Handle the incoming request.

--- a/src/Post.php
+++ b/src/Post.php
@@ -120,21 +120,19 @@ class Post extends Model
     /**
      * Get the user who authored the post.
      *
-     * @param $value
      * @return User
      */
-    public function getAuthorAttribute($value): User
+    public function getAuthorAttribute(): User
     {
-        return User::find($this->user_id);
+        return $this->user;
     }
 
     /**
      * Check to see if the post is published.
      *
-     * @param $value
      * @return bool
      */
-    public function getPublishedAttribute($value): bool
+    public function getPublishedAttribute(): bool
     {
         if ($this->published_at <= now()->toDateTimeString()) {
             return true;
@@ -146,10 +144,9 @@ class Post extends Model
     /**
      * Get the human-friendly estimated reading time of a post.
      *
-     * @param $value
      * @return string
      */
-    public function getReadTimeAttribute($value): string
+    public function getReadTimeAttribute(): string
     {
         // Only count words in our estimation
         $words = str_word_count(strip_tags($this->body));
@@ -163,13 +160,12 @@ class Post extends Model
     /**
      * Get the 10 most popular reading times rounded to the nearest 30 minutes.
      *
-     * @param $value
      * @return array
      */
-    public function getPopularReadingTimesAttribute($value): array
+    public function getPopularReadingTimesAttribute(): array
     {
         // Get the views associated with the post
-        $data = View::where('post_id', $this->id)->get();
+        $data = $this->views;
 
         // Filter the view data to only include hours:minutes
         $collection = collect();
@@ -182,7 +178,6 @@ class Post extends Model
 
         $popular_reading_times = collect();
         foreach ($filtered as $key => $value) {
-
             // Use each given time to create a 60 min range
             $start_time = Carbon::createFromTimeString($key);
             $end_time = $start_time->copy()->addMinutes(60);
@@ -191,7 +186,10 @@ class Post extends Model
             $percentage = number_format($value / $data->count() * 100, 2);
 
             // Get a human-readable hour range and floating percentage
-            $popular_reading_times->put(sprintf('%s - %s', $start_time->format('g:i A'), $end_time->format('g:i A')), $percentage);
+            $popular_reading_times->put(
+                sprintf('%s - %s', $start_time->format('g:i A'), $end_time->format('g:i A')),
+                $percentage
+            );
         }
 
         // Cast the collection to an array
@@ -209,10 +207,9 @@ class Post extends Model
     /**
      * Get the top 10 referring websites for a post.
      *
-     * @param $value
      * @return array
      */
-    public function getTopReferersAttribute($value): array
+    public function getTopReferersAttribute(): array
     {
         // Get the views associated with the post
         $data = $this->views;
@@ -238,10 +235,9 @@ class Post extends Model
     /**
      * Return a view count for the last 30 days.
      *
-     * @param $value
      * @return array
      */
-    public function getViewTrendAttribute($value): array
+    public function getViewTrendAttribute(): array
     {
         // Get the views associated with the post
         $data = $this->views;


### PR DESCRIPTION
- reduce redundancy
- move resource handling from `register()` to service provider's `boot()` method, as encouraged by [doc](https://laravel.com/docs/5.8/providers#the-register-method).