### PR TITLE
add canonical link support

### DIFF
--- a/resources/lang/ar/posts.php
+++ b/resources/lang/ar/posts.php
@@ -95,6 +95,10 @@ return [
                     'placeholder' => 'الوصف في بطاقة تويتر',
                 ],
             ],
+            'canonical'  => [
+                'label'       => 'العنوان الأساسي',
+                'placeholder' => 'عنوان URL الكنسي في العلامة',
+            ],
         ],
         'settings' => [
             'header'  => 'الاعدادات العامة',

--- a/resources/lang/cn/posts.php
+++ b/resources/lang/cn/posts.php
@@ -95,6 +95,10 @@ return [
                     'placeholder' => 'Twitter卡中的描述',
                 ],
             ],
+            'canonical'  => [
+                'label'       => '典范',
+                'placeholder' => '标签中的规范URL',
+            ],
         ],
         'settings' => [
             'header'  => '常規設置',

--- a/resources/lang/de/posts.php
+++ b/resources/lang/de/posts.php
@@ -95,6 +95,10 @@ return [
                     'placeholder' => 'Beschreibung in Twitter Card',
                 ],
             ],
+            'canonical'  => [
+                'label'       => 'Kanonisch',
+                'placeholder' => 'Kanonische URL im Tag',
+            ],
         ],
         'settings' => [
             'header'  => 'Allgemeine Einstellungen',

--- a/resources/lang/en/posts.php
+++ b/resources/lang/en/posts.php
@@ -95,6 +95,10 @@ return [
                     'placeholder' => 'Description in Twitter Card',
                 ],
             ],
+            'canonical'  => [
+                'label'       => 'Canonical',
+                'placeholder' => 'Canonical URL in tag',
+            ],
         ],
         'settings' => [
             'header'  => 'General settings',

--- a/resources/lang/es/posts.php
+++ b/resources/lang/es/posts.php
@@ -95,6 +95,10 @@ return [
                     'placeholder' => 'Descripción en la tarjeta de Twitter',
                 ],
             ],
+            'canonical'  => [
+                'label'       => 'Canonical',
+                'placeholder' => 'Canonical URL para tag',
+            ],
         ],
         'settings' => [
             'header'  => 'Configuración general',

--- a/resources/lang/fr/posts.php
+++ b/resources/lang/fr/posts.php
@@ -95,6 +95,10 @@ return [
                     'placeholder' => 'Description de l\'encart Twitter',
                 ],
             ],
+            'canonical'  => [
+                'label'       => 'Canonique',
+                'placeholder' => 'URL canonique dans la balise',
+            ],
         ],
         'settings' => [
             'header'  => 'Réglages généraux',

--- a/resources/lang/pt/posts.php
+++ b/resources/lang/pt/posts.php
@@ -95,6 +95,10 @@ return [
                     'placeholder' => 'Descrição no Twitter Card',
                 ],
             ],
+            'canonical'  => [
+                'label'       => 'Canônico',
+                'placeholder' => 'URL canônico na tag',
+            ],
         ],
         'settings' => [
             'header'  => 'Configurações Gerais',

--- a/resources/lang/ru/posts.php
+++ b/resources/lang/ru/posts.php
@@ -95,6 +95,10 @@ return [
                     'placeholder' => 'Описание в Твиттере',
                 ],
             ],
+            'canonical'  => [
+                'label'       => 'канонический',
+                'placeholder' => 'Канонический URL в теге',
+            ],
         ],
         'settings' => [
             'header'  => 'Общие настройки',

--- a/resources/views/components/modals/post/create/seo.blade.php
+++ b/resources/views/components/modals/post/create/seo.blade.php
@@ -45,6 +45,14 @@
                                   title="{{ __('canvas::posts.forms.seo.twitter.description.label') }}">{{ old('twitter_description') }}</textarea>
                     </div>
                 </div>
+                <div class="form-group row">
+                    <div class="col-12">
+                        <label for="canonical_link" class="font-weight-bold">{{ __('canvas::posts.forms.seo.canonical.label') }}</label>
+                        <input type="text" class="form-control border-0 px-0"
+                               name="canonical_link" title="{{ __('canvas::posts.forms.seo.canonical.label') }}" value="{{ old('canonical_link') }}"
+                               placeholder="{{ __('canvas::posts.forms.seo.canonical.placeholder') }}">
+                    </div>
+                </div>
             </div>
             <div class="modal-footer">
                 <button class="btn btn-link text-muted" data-dismiss="modal">{{ __('canvas::buttons.general.done') }}</button>

--- a/resources/views/components/modals/post/edit/seo.blade.php
+++ b/resources/views/components/modals/post/edit/seo.blade.php
@@ -44,6 +44,14 @@
                                   title="{{ __('canvas::posts.forms.seo.twitter.description.label') }}">{{ $data['meta']['twitter_description'] }}</textarea>
                     </div>
                 </div>
+                <div class="form-group row">
+                    <div class="col-12">
+                        <label for="canonical_link" class="font-weight-bold">{{ __('canvas::posts.forms.seo.canonical.label') }}</label>
+                        <input type="text" class="form-control border-0 px-0"
+                               name="canonical_link" title="{{ __('canvas::posts.forms.seo.canonical.label') }}" value="{{ $data['meta']['canonical_link'] }}"
+                               placeholder="{{ __('canvas::posts.forms.seo.canonical.placeholder') }}">
+                    </div>
+                </div>
             </div>
             <div class="modal-footer">
                 <button class="btn btn-link text-muted" data-dismiss="modal">{{ __('canvas::buttons.general.done') }}</button>

--- a/src/Http/Controllers/PostController.php
+++ b/src/Http/Controllers/PostController.php
@@ -89,6 +89,7 @@ class PostController extends Controller
                 'og_description'      => request('og_description', null),
                 'twitter_title'       => request('twitter_title', null),
                 'twitter_description' => request('twitter_description', null),
+                'canonical_link'      => request('canonical_link', null),
             ],
         ];
 
@@ -146,6 +147,7 @@ class PostController extends Controller
                 'og_description'      => request('og_description', null),
                 'twitter_title'       => request('twitter_title', null),
                 'twitter_description' => request('twitter_description', null),
+                'canonical_link'      => request('canonical_link', null),
             ],
         ];
 

--- a/stubs/views/blog/show.stub
+++ b/stubs/views/blog/show.stub
@@ -13,6 +13,7 @@
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="{{ $data['meta']['twitter_description'] }}">
     <meta name="twitter:description" content="{{ $data['meta']['twitter_description'] }}">
+    <link rel="canonical" href="{{ $data['meta']['canonical_link'] }}" />
     @isset($data['post']->featured_image)
         <meta name="og:image" content="{{ url($data['post']->featured_image) }}">
         <meta name="twitter:image" content="{{ url($data['post']->featured_image) }}">

--- a/stubs/views/blog/show.stub
+++ b/stubs/views/blog/show.stub
@@ -13,7 +13,11 @@
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="{{ $data['meta']['twitter_description'] }}">
     <meta name="twitter:description" content="{{ $data['meta']['twitter_description'] }}">
-    <link rel="canonical" href="{{ $data['meta']['canonical_link'] }}" />
+
+    @isset($data['meta']['canonical_link'])
+        <link rel="canonical" href="{{ $data['meta']['canonical_link'] }}" />
+    @endisset
+    
     @isset($data['post']->featured_image)
         <meta name="og:image" content="{{ url($data['post']->featured_image) }}">
         <meta name="twitter:image" content="{{ url($data['post']->featured_image) }}">


### PR DESCRIPTION
Add Canonical Link field seo create & edit modals.

[What is a Canonical URL?](https://blog.alexa.com/canonical-url/
)

> When You Repost Existing Content
If you have a website that is a part of a franchise or national organization, then you may share statements, press releases, and even blog content originally published on the main national website. Instead of merely linking to the original content and hoping site visitors click through, you may publish the content on your own site. This is duplicate content that needs a canonical tag. You can use a canonical URL to direct search crawlers to the original post so that it doesn’t look like you are copying the page.

this still needs a way to prevent "Undefined index: canonical_link" when trying to edit a post created before this field existed.