### PR TITLE
Add ability to use Medium.com import Tool

### DIFF
--- a/stubs/views/blog/layouts/app.stub
+++ b/stubs/views/blog/layouts/app.stub
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" prefix="og: http://ogp.me/ns#">
 <head>
     <!-- Meta -->
     @stack('meta')

--- a/stubs/views/blog/show.stub
+++ b/stubs/views/blog/show.stub
@@ -7,7 +7,9 @@
 @endpush
 
 @push('meta')
+
     <meta name="description" content="{{ $data['meta']['meta_description'] }}">
+    <meta property="og:type" content="article">
     <meta name="og:title" content="{{ $data['meta']['og_title'] }}">
     <meta name="og:description" content="{{ $data['meta']['og_description'] }}">
     <meta name="twitter:card" content="summary">


### PR DESCRIPTION
Hello,
I was trying to import some of my blog posts to [medium](https://medium.com/) using the [import tool](https://help.medium.com/hc/en-us/articles/214550207-Import-a-post), but it was failing.

I found the solution here:[Medium.com Import Tool Fails
](https://keepinguptodate.com/pages/2019/05/medium.com-import-tool-failed/
)
turns out it was a very simple fix, hope this is usefull to others.