### PR TITLE
fixes error #545 when malicious code as referer

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -216,7 +216,7 @@ class Post extends Model
         // Filter the view data to only include referrers
         $collection = collect();
         $data->each(function ($item, $key) use ($collection) {
-            empty($item->referer) ? $collection->push(__('canvas::stats.details.referer.other')) : $collection->push(parse_url($item->referer)['host']);
+            empty(parse_url($item->referer)['host']) ? $collection->push(__('canvas::stats.details.referer.other')) : $collection->push(parse_url($item->referer)['host']);
         });
 
         // Count the unique values and assign to their respective keys


### PR DESCRIPTION
This only checks the not well-formed URL already in the database. Provably a better solution would be to avoid writing that not well-formed URL to the database.