### PR TITLE
Fix: restore deleted topic/tag when adding new with the same slug

### DIFF
--- a/src/Http/Controllers/TagController.php
+++ b/src/Http/Controllers/TagController.php
@@ -71,11 +71,21 @@ class TagController extends Controller
             'slug' => [
                 'required',
                 'alpha_dash',
-                Rule::unique('canvas_tags', 'slug')->ignore($id),
+                Rule::unique('canvas_tags', 'slug')->ignore($id)->whereNull('deleted_at'),
             ],
         ], $messages)->validate();
 
-        $tag = $id !== 'create' ? Tag::find($id) : new Tag(['id' => request('id')]);
+        if ($id !== 'create') {
+            $tag = Tag::find($id);
+        }
+        else {
+            if ($tag = Tag::onlyTrashed()->where('slug', request('slug'))->first()) {
+                $tag->restore();
+            }
+            else {
+                $tag = new Tag(['id' => request('id')]);
+            }
+        }
 
         $tag->fill($data);
         $tag->save();

--- a/src/Http/Controllers/TopicController.php
+++ b/src/Http/Controllers/TopicController.php
@@ -71,11 +71,21 @@ class TopicController extends Controller
             'slug' => [
                 'required',
                 'alpha_dash',
-                Rule::unique('canvas_topics', 'slug')->ignore($id),
+                Rule::unique('canvas_topics', 'slug')->ignore($id)->whereNull('deleted_at'),
             ],
         ], $messages)->validate();
 
-        $topic = $id !== 'create' ? Topic::find($id) : new Topic(['id' => request('id')]);
+        if ($id !== 'create') {
+            $topic = Topic::find($id);
+        }
+        else {
+            if ($topic = Topic::onlyTrashed()->where('slug', request('slug'))->first()) {
+                $topic->restore();
+            }
+            else {
+                $topic = new Topic(['id' => request('id')]);
+            }
+        }
 
         $topic->fill($data);
         $topic->save();


### PR DESCRIPTION
Fix for issue when adding already deleted topic/tag. The one already exists in DB since the slug is unique and user get an error. So I've added ignoring of deleted topics/tags during check and before model creating, it check if the one exist in deleted and restore it if so.