### PR TITLE
fix: only allow users to view their own posts

### DIFF
--- a/src/Http/Controllers/PostController.php
+++ b/src/Http/Controllers/PostController.php
@@ -20,7 +20,7 @@ class PostController extends Controller
      */
     public function index(): JsonResponse
     {
-        return response()->json(Post::forUser(request()->user()->id)
+        return response()->json(Post::forCurrentUser()
             ->orderByDesc('created_at')
             ->get());
     }
@@ -50,7 +50,7 @@ class PostController extends Controller
             ]);
         } else {
             return response()->json([
-                'post'   => Post::with('tags:name,slug', 'topic:name,slug')->find($id),
+                'post'   => Post::forCurrentUser()->with('tags:name,slug', 'topic:name,slug')->find($id),
                 'tags'   => $tags,
                 'topics' => $topics,
             ]);
@@ -100,7 +100,7 @@ class PostController extends Controller
             ],
         ], $messages)->validate();
 
-        $post = $id !== 'create' ? Post::find($id) : new Post(['id' => request('id')]);
+        $post = $id !== 'create' ? Post::forCurrentUser()->find($id) : new Post(['id' => request('id')]);
 
         $post->fill($data);
         $post->meta = $data['meta'];

--- a/src/Http/Controllers/StatsController.php
+++ b/src/Http/Controllers/StatsController.php
@@ -26,7 +26,8 @@ class StatsController extends Controller
      */
     public function index(): JsonResponse
     {
-        $published = Post::published()
+        $published = Post::forCurrentUser()
+            ->published()
             ->orderByDesc('created_at')
             ->withCount('views')
             ->get();
@@ -62,7 +63,7 @@ class StatsController extends Controller
      */
     public function show(string $id): JsonResponse
     {
-        $post = Post::find($id);
+        $post = Post::forCurrentUser()->find($id);
 
         if ($post && $post->published) {
             return response()->json([

--- a/src/Post.php
+++ b/src/Post.php
@@ -259,9 +259,26 @@ class Post extends Model
         return $query->where('published_at', null)->orWhere('published_at', '>', now()->toDateTimeString());
     }
 
+    /**
+     * Scope a query to only include posts for a specific user.
+     *
+     * @param Builder $query
+     * @return Builder
+     */
     public function scopeForUser($query, $user): Builder
     {
         return $query->where('user_id', $user);
+    }
+
+    /**
+     * Scope a query to only include posts for the current logged in user.
+     *
+     * @param Builder $query
+     * @return Builder
+     */
+    public function scopeForCurrentUser($query): Builder
+    {
+        return $query->where('user_id', request()->user()->id ?? null);
     }
 
     /**


### PR DESCRIPTION
@austintoddj mentioned that post permissions were resolved in #572 but after downloading and testing the `develop` branch it seems that the clause was only added to that single case. For example, the "stats" page (the default page you land on) still exposes all users posts (and you can edit them).

This PR should fix all of the different cases. I would had added tests but there's no integration set up in the project (i'll add some when I have time).

Thanks!