### PR TITLE
Use count of users to determine availability of users

### DIFF
--- a/src/Console/SetupCommand.php
+++ b/src/Console/SetupCommand.php
@@ -59,7 +59,7 @@ class SetupCommand extends Command
 
         // Optionally seed the database with demo data
         if ($this->option('data')) {
-            if (User::find(1)) {
+            if (User::count() > 0) {
                 $this->seed();
             } else {
                 $this->error('No users found. Please create a user and re-run the setup.');


### PR DESCRIPTION
When `--data` is specified for the `canvas:setup` command, the check done to confirm availability of users assumes the existence of a user that has an id of 1.

While I won't bother to go into the details of several reasons why old/legacy codebases may have users without id=1, I will simply submit that such check does not effectively check for presence of users in the database.

Currently, absence of a user whose id=1 will cause the `--data` option to be ineffective.

This PR fixes this.