### PR TITLE
Allow anything that implements the DateTimeInterface

### DIFF
--- a/src/Http/Middleware/Session.php
+++ b/src/Http/Middleware/Session.php
@@ -2,11 +2,11 @@
 
 namespace Canvas\Http\Middleware;
 
-use Carbon\Carbon;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
 
 class Session
 {
@@ -84,7 +84,7 @@ class Session
     private function pruneExpiredVisits(Collection $posts)
     {
         foreach ($posts as $key => $value) {
-            if (! Carbon::createFromTimestamp($value['timestamp'])->isToday()) {
+            if (! Date::createFromTimestamp($value['timestamp'])->isToday()) {
                 session()->forget('visited_posts.'.$key);
             }
         }

--- a/src/Post.php
+++ b/src/Post.php
@@ -2,12 +2,12 @@
 
 namespace Canvas;
 
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 
 class Post extends Model
@@ -206,7 +206,7 @@ class Post extends Model
         $popular_reading_times = collect();
         foreach ($filtered as $key => $value) {
             // Use each given time to create a 60 min range
-            $start_time = Carbon::createFromTimeString($key);
+            $start_time = Date::createFromTimeString($key);
             $end_time = $start_time->copy()->addMinutes(60);
 
             // Find the percentage based on the value

--- a/src/Tracker.php
+++ b/src/Tracker.php
@@ -2,10 +2,10 @@
 
 namespace Canvas;
 
-use Carbon\Carbon;
 use Carbon\CarbonInterval;
 use DateInterval;
 use DatePeriod;
+use DateTimeInterface;
 use Illuminate\Support\Collection;
 
 trait Tracker
@@ -126,13 +126,13 @@ trait Tracker
     /**
      * Generate a date range array of formatted strings.
      *
-     * @param Carbon $start_date
+     * @param DateTimeInterface $start_date
      * @param DateInterval $interval
      * @param int $recurrences
      * @param int $exclusive
      * @return array
      */
-    private function generateDateRange(Carbon $start_date, DateInterval $interval, int $recurrences, int $exclusive = 1): array
+    private function generateDateRange(DateTimeInterface $start_date, DateInterval $interval, int $recurrences, int $exclusive = 1): array
     {
         $period = new DatePeriod($start_date, $interval, $recurrences, $exclusive);
         $dates = collect();


### PR DESCRIPTION
I'm using immutable dates in my application (https://laravel-news.com/carbon-2-laravel), so the Stats page doesn't load (the API returns a 500 error).

This will allow anyone that is using any class that implements the `DateTimeInterface` as their default to use Canvas without errors.