### PR TITLE
Add ability to publish translations

### DIFF
--- a/src/CanvasServiceProvider.php
+++ b/src/CanvasServiceProvider.php
@@ -121,6 +121,10 @@ class CanvasServiceProvider extends ServiceProvider
             ], 'canvas-config');
 
             $this->publishes([
+                __DIR__.'/../resources/lang' => resource_path('lang/vendor/canvas'),
+            ], 'canvas-lang');
+
+            $this->publishes([
                 __DIR__.'/../resources/stubs/CanvasServiceProvider.stub' => app_path(
                     'Providers/CanvasServiceProvider.php'
                 ),


### PR DESCRIPTION
I have them individually tagged by language (as well as the global `canvas-lang`), but we could just go with the `canvas-lang` tag and make the developer remove the ones they don't want to override. It's up to you.

The only downside I can see with doing it this way is maintaining it when someone adds a new language.