### PR TITLE
Load translations from Laravel

### DIFF
--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -21,7 +21,7 @@ class Canvas
         return [
             'avatar' => optional($metaData)->avatar && ! empty(optional($metaData)->avatar) ? $metaData->avatar : "https://secure.gravatar.com/avatar/{$emailHash}?s=500",
             'darkMode' => optional($metaData)->dark_mode,
-            'lang' => self::compileLanguageFile(config('app.locale')),
+            'lang' => collect(['app' => trans('canvas::app')])->toJson(),
             'locale' => config('app.locale'),
             'maxUpload' => config('canvas.upload_filesize'),
             'path' => config('canvas.path'),
@@ -45,23 +45,5 @@ class Canvas
         }
 
         return File::get($path) === File::get(__DIR__.'/../public/mix-manifest.json');
-    }
-
-    /**
-     * Compiles the language file and rebuilds it into into a single
-     * consumable JSON object that can be used in the Vue components.
-     *
-     * @param string
-     * @return string
-     */
-    private static function compileLanguageFile(string $locale): string
-    {
-        $langDirectory = dirname(__DIR__, 1).'/resources/lang';
-        $file = "{$langDirectory}/{$locale}/app.php";
-
-        $lines = collect();
-        $lines->put('app', include $file);
-
-        return $lines->toJson();
     }
 }


### PR DESCRIPTION
This allows translations to be overridden by the developer if necessary.

This is a companion to #657 but is necessary for overloading translations to work correctly.