### PR TITLE
Fix Bug class Locale not found

### DIFF
--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -59,7 +59,7 @@ class Canvas
         $translations = collect();
 
         foreach ($locales as $locale) {
-            $translations->put($locale, Str::ucfirst($locale, $locale));
+            $translations->put($locale, Str::ucfirst($locale));
         }
 
         return $translations->toArray();

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -4,7 +4,6 @@ namespace Canvas;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
-use Locale;
 use RuntimeException;
 
 class Canvas
@@ -60,7 +59,7 @@ class Canvas
         $translations = collect();
 
         foreach ($locales as $locale) {
-            $translations->put($locale, Str::ucfirst(Locale::getDisplayName($locale, $locale)));
+            $translations->put($locale, Str::ucfirst($locale, $locale));
         }
 
         return $translations->toArray();


### PR DESCRIPTION
This error is triggered when you want to access the route /canvas after connection.