### PR TITLE
Choose domain to use canvas in.

### DIFF
--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::namespace('Canvas\Http\Controllers')->group(function () {
+Route::domain(config('canvas.domain'))->namespace('Canvas\Http\Controllers')->group(function () {
     Route::prefix(config('canvas.path'))->middleware(config('canvas.middleware'))->group(function () {
         Route::prefix('api')->group(function () {
             Route::prefix('stats')->group(function () {


### PR DESCRIPTION
Users can choose the domain or sub-domain they want canvas to be associated with.