### PR TITLE
Use method store instead of storePublicly for Media uploads

### DIFF
--- a/src/Http/Controllers/MediaController.php
+++ b/src/Http/Controllers/MediaController.php
@@ -21,7 +21,7 @@ class MediaController extends Controller
         $file = reset($payload);
 
         if ($file instanceof UploadedFile) {
-            $path = $file->storePublicly($this->getBaseStoragePath(), [
+            $path = $file->store($this->getBaseStoragePath(), [
                 'disk' => config('canvas.storage_disk'),
             ]);
 


### PR DESCRIPTION
The `storePublicly` method fails to upload files when an AWS S3 bucket doesn't have read access. The `visibility` config on `filesystems.php` can be used to set the visibility of the file uploads and the `store` method takes into consideration the access using it. This applies to drivers supported by laravel. Fix for issue #571 